### PR TITLE
Split the sweep by task state: barrier reporting and a faster clean exit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EpiModelHPC
-Version: 2.6.4
+Version: 2.7.0
 Date: 2024-10-18
 Title: EpiModel Extensions for High-Performance Computing
 Description: Extension package to EpiModel to run large-scale stochastic network

--- a/R/hpc_doctor.R
+++ b/R/hpc_doctor.R
@@ -221,6 +221,16 @@ doctor_step_sbatch_opts <- function(sbatch_opts) {
 #'   directory is then empty, stops the doctor.
 #' }
 #'
+#' Pass the same directory to the doctor itself as \code{WATCH_DIR} when you
+#' submit it. The teardown step is the primary stop signal and is immediate, but
+#' the doctor also self-terminates after a run of empty sweeps, and \code{WATCH_DIR}
+#' is what tells it which kind of empty queue it is looking at. With a campaign
+#' still registered it waits the full \code{IDLE_EXIT}, treating an empty queue as
+#' a lull between steps; with nothing registered it exits after the shorter
+#' \code{IDLE_FAST}. The watch list only ever makes it more patient, and
+#' \code{IDLE_EXIT} still caps the wait, so a stale marker left by a workflow that
+#' died before its teardown ran cannot hold the doctor open to its walltime.
+#'
 #' Because each campaign removes its own marker before testing emptiness,
 #' whichever campaign finishes last always observes an empty directory. No
 #' concurrent sibling is ever left unmonitored, and there is no interleaving in

--- a/inst/hpc_doctor/README.md
+++ b/inst/hpc_doctor/README.md
@@ -46,6 +46,35 @@ The guards are therefore all fail-loud, and all fire before the first sweep rath
 - `degen_watch.sh` exits non-zero if `probe_node_cpu.sh` is not readable under `ROOT`.
 - `degen_watch.sh` treats a sweep in which no node returned any probe output as a broken probe rather than a healthy campaign. Remote stderr is discarded, so a probe that could not run anywhere previously yielded zero suspects and a confident `all tasks healthy`. That is the most dangerous member of this class, because the doctor actively asserts the campaign is fine.
 
+## When the doctor stops
+
+Three signals, in decreasing order of authority.
+
+`add_doctor_teardown_step()` scancels the doctor when the last registered campaign finishes. This is the normal path and it is immediate. Everything below is fallback for when it does not fire: a doctor launched without the watch-list steps, or a workflow that died before reaching its teardown.
+
+`WATCH_DIR`, the same watch list the teardown maintains, passed to the doctor at submit time. It tells the doctor which kind of empty queue it is looking at. With a campaign still registered, an empty queue is a lull between steps, so the doctor waits the full `IDLE_EXIT` (6 sweeps, an hour at the default interval). With nothing registered it exits after `IDLE_FAST` (2 sweeps, 20 minutes). Give it the same path passed to `add_doctor_register_step()`; a relative path is resolved against the submission directory, not against `ROOT`.
+
+The queue itself, which is the backstop. The watch list can only make the doctor more patient, never less, and `IDLE_EXIT` still caps the wait either way. That is deliberate: a workflow killed before its teardown step leaves a marker behind forever, and without the cap that stale marker would hold a doctor open until its three-day walltime, which is worse than the hour this was meant to fix.
+
+The `seen` gate is unchanged and still comes first. A doctor launched at campaign start, before its netsim array exists, never exits on an empty queue no matter what the watch list says, because step 1's renv restore can run 180 minutes.
+
+Measured on a live campaign, 2026-07-27 to 28: 103 sweeps over 20.5 hours, and the matching-task count never once reached zero. Empty-queue states during a running campaign are rare, which is why `IDLE_FAST` can be as small as 2.
+
+## Pending-side barriers
+
+The detector reasons about running tasks. A task that is slow but running reads healthy CPU and is correctly spared; a stalled one reads low CPU or D-state and is caught. A task that is PENDING has neither signal, and it can still be the thing gating everything: slurmworkflow only submits the next slice when the last task of the current one finishes, so one queued straggler stops all netsim progress.
+
+The doctor cannot fix this, and deliberately does not try. Submitting the next slice early is the double-write corruption risk described in `deploy_doctor.sh`'s header. What it now does is stop hiding it. Sweeps with tasks pending and none running are counted, and past `BARRIER_WARN` (3) each one reports the barrier's duration and every pending task's SLURM reason:
+
+```
+sweep=57 !! BARRIER matching_tasks=1 (0 running, 1 pending) for 90m -- no netsim progress
+    pending 41746874_33     reason=Resources
+```
+
+The reason field is what separates a scheduler-starved task from one blocked for another cause, including a task the doctor itself requeued to the back of a deep queue. That last case is real: a requeued array task gets a new `SubmitTime` and re-enters behind everything submitted earlier, so a requeue meant to rescue a slice can become the slice barrier. In the India rollout this ran for nine hours across 55 consecutive sweeps, each logging an ordinary-looking `sweeping` line followed by `no running tasks`.
+
+Counting now uses `squeue -r`, so a collapsed pending range such as `41746874_[46-63]` contributes the 18 tasks it really holds rather than 1. On a live campaign that changed the reported count from 26 to 43. Expect `matching_tasks` to read higher than it used to for the same queue.
+
 ## Guardrails, each of which was a bug first
 
 - Sample `/proc/<pid>/stat` twice and difference it. `ps %cpu` is a lifetime average and would hide a task that ran healthy and then got starved, which is the transition being hunted.

--- a/inst/hpc_doctor/deploy_doctor.sh
+++ b/inst/hpc_doctor/deploy_doctor.sh
@@ -39,17 +39,67 @@
 ## `scancel --name=deploy_doctor`. If you rename the job to scope it to one
 ## project, pass the same name to that function or teardown will not find it.
 ##
+## WHEN THE DOCTOR STOPS (issue #54). Three signals, in order of authority:
+##   1. `add_doctor_teardown_step()` scancels it when the LAST registered
+##      campaign finishes. This is the normal path and it is immediate.
+##   2. WATCH_DIR, the same watch list that teardown maintains. If it is set and
+##      non-empty, a campaign is still registered, so an empty queue is a lull
+##      between steps and the doctor waits the full IDLE_EXIT before believing
+##      it. The watch list can only make the doctor MORE patient, never less.
+##   3. The queue itself. With no campaign registered, an empty queue for
+##      IDLE_FAST sweeps is enough. This is also the backstop that keeps a stale
+##      marker (a workflow that died before its teardown ran) from pinning the
+##      doctor to its walltime: IDLE_EXIT still caps the wait either way.
+## Measured 2026-07-27/28 on a live doxy campaign: 103 sweeps over 20.5h, and
+## the matching-task count never once reached zero. Empty-queue states during a
+## running campaign are rare, which is why IDLE_FAST can be small.
+##
+## PENDING-SIDE BARRIERS (issue #55). slurmworkflow submits netsim in slices and
+## the next slice only goes in when the LAST task of the current one finishes, so
+## a single queued straggler gates the whole slice. There is no process to probe,
+## so the CPU/D-state detector cannot see it: the old loop just logged a normal
+## "sweeping" line and then found nothing running. Observed for nine hours (55
+## consecutive sweeps) in the India rollout. Sweeps with tasks pending and none
+## running are now counted and, past BARRIER_WARN, reported with each pending
+## task's SLURM reason. This is observability only; it does not touch slice
+## progression, so it carries none of the double-write risk described above.
+##
 ## Usage (standalone, alongside any campaign):
 ##   PATTERN='doxy-' sbatch --partition=<yours> deploy_doctor.sh
 ##   PATTERN='swfcalib_step' sbatch --partition=<yours> deploy_doctor.sh
+## With the watch list, so a shared doctor outlives any one campaign:
+##   PATTERN='doxy-' WATCH_DIR=data/run/.doctor_watch sbatch ... deploy_doctor.sh
 ## From R, to get the installed path:
 ##   EpiModelHPC::hpc_doctor_script("deploy_doctor.sh")
 ## Output lands in deploy_doctor-<jobid>.out in the submission directory.
 set -u
 PATTERN=${PATTERN:?set PATTERN to a regex matching your job names, e.g. 'swfcalib_step'}
 INTERVAL=${INTERVAL:-600}      # seconds between sweeps
-IDLE_EXIT=${IDLE_EXIT:-6}      # consecutive empty sweeps before self-terminating
+IDLE_EXIT=${IDLE_EXIT:-6}      # empty sweeps before exiting while a campaign is still registered
+IDLE_FAST=${IDLE_FAST:-2}      # empty sweeps before exiting when none is
+BARRIER_WARN=${BARRIER_WARN:-3}  # pending-only sweeps before reporting a barrier
+WATCH_DIR=${WATCH_DIR:-}       # optional; the watch list add_doctor_register_step maintains
 ACT=${ACT---requeue}          # set ACT='' for report-only
+
+# Resolve WATCH_DIR against the SUBMISSION directory, before the `cd "$ROOT"`
+# below moves us into the installed package. `add_doctor_register_step()`
+# documents its watch_dir as relative to the repository root, which is where the
+# doctor is submitted from, so a bare `data/run/.doctor_watch` has to mean that
+# and not a path inside the renv library.
+if [ -n "$WATCH_DIR" ]; then
+  case "$WATCH_DIR" in
+    /*) ;;
+    *) WATCH_DIR="${SLURM_SUBMIT_DIR:-$PWD}/$WATCH_DIR" ;;
+  esac
+fi
+
+# Non-empty watch list means at least one campaign has registered and not yet
+# torn down. Absent or empty means nothing claims to be live.
+watch_list_live() {
+  [ -n "$WATCH_DIR" ] || return 1
+  [ -d "$WATCH_DIR" ] || return 1
+  [ -n "$(ls -A "$WATCH_DIR" 2>/dev/null)" ]
+}
 
 # --- locate the sibling scripts -------------------------------------------
 # `sbatch` COPIES the submitted script into the node's spool directory and runs
@@ -92,12 +142,24 @@ for dep in degen_watch.sh probe_node_cpu.sh; do
     exit 1
   }
 done
-echo "[doctor] start $(date -Is) host=$(hostname) pattern=/$PATTERN/ interval=${INTERVAL}s act=${ACT:-report-only}"
-idle=0; sweep=0; seen=0
+echo "[doctor] start $(date -Is) host=$(hostname) pattern=/$PATTERN/ interval=${INTERVAL}s act=${ACT:-report-only} watch_dir=${WATCH_DIR:-none}"
+idle=0; sweep=0; seen=0; barrier=0
 while :; do
   sweep=$((sweep+1))
-  n=$(squeue -u "$USER" -h -t RUNNING,PENDING -o "%j" 2>/dev/null | grep -Ec "$PATTERN" || true)
-  if [ "${n:-0}" -eq 0 ]; then
+  # One squeue pass, split by state. Both #54 and #55 turn on this split:
+  # RUNNING is the only state the probe can measure, PENDING is what gates a
+  # slice barrier, and only "neither" means the campaign is actually over.
+  # `-r` expands array elements so a collapsed pending range counts as the tasks
+  # it really holds. Without it a row like 41746874_[46-63] counted as one, which
+  # understated pending work about twofold on a live campaign (26 vs 43).
+  states=$(squeue -u "$USER" -h -r -t RUNNING,PENDING -o "%T|%j" 2>/dev/null \
+           | awk -F'|' -v pat="$PATTERN" '$2 ~ pat {print $1}')
+  n_run=$(grep -cx RUNNING <<< "$states" || true)
+  n_pend=$(grep -cx PENDING <<< "$states" || true)
+  n=$((n_run + n_pend))
+
+  if [ "$n" -eq 0 ]; then
+    barrier=0
     idle=$((idle+1))
     # Only treat "no tasks" as END-of-campaign once we have actually SEEN work.
     # Otherwise a doctor launched at campaign start (e.g. from step 1, or from the
@@ -106,14 +168,38 @@ while :; do
     if [ "$seen" -eq 0 ]; then
       echo "[doctor] $(date -Is) sweep=$sweep waiting for campaign to start (no tasks yet)"
     else
-      echo "[doctor] $(date -Is) sweep=$sweep no matching tasks (idle ${idle}/${IDLE_EXIT})"
-      if [ "$idle" -ge "$IDLE_EXIT" ]; then
+      if watch_list_live; then
+        thr=$IDLE_EXIT; why="a campaign is still registered in the watch list"
+      else
+        thr=$IDLE_FAST; why="no campaign registered"
+      fi
+      # Never wait longer than the old ceiling. This is what stops a stale marker,
+      # left by a workflow that died before its teardown step ran, from holding
+      # the doctor open until its walltime.
+      [ "$thr" -gt "$IDLE_EXIT" ] && thr=$IDLE_EXIT
+      echo "[doctor] $(date -Is) sweep=$sweep no matching tasks (idle ${idle}/${thr}; ${why})"
+      if [ "$idle" -ge "$thr" ]; then
         echo "[doctor] $(date -Is) campaign appears finished; exiting cleanly"; break
       fi
     fi
+  elif [ "$n_run" -eq 0 ]; then
+    # Tasks queued, none running: a pending-side barrier. Nothing to probe, so
+    # the sweep is skipped rather than run to report "no running tasks".
+    idle=0; seen=1; barrier=$((barrier+1))
+    if [ "$barrier" -ge "$BARRIER_WARN" ]; then
+      echo "[doctor] $(date -Is) sweep=$sweep !! BARRIER matching_tasks=$n (0 running, ${n_pend} pending) for $((barrier * INTERVAL / 60))m -- no netsim progress"
+      # The reason field separates a scheduler-starved task (Priority, Resources)
+      # from one held or blocked for another cause, including a task the doctor
+      # itself requeued to the back of a deep queue.
+      squeue -u "$USER" -h -r -t PENDING -o "%i|%j|%r" 2>/dev/null \
+        | awk -F'|' -v pat="$PATTERN" '$2 ~ pat {printf "[doctor]     pending %-16s reason=%s\n", $1, $3}' \
+        | head -10
+    else
+      echo "[doctor] $(date -Is) sweep=$sweep matching_tasks=$n (0 running, ${n_pend} pending) -- nothing to probe"
+    fi
   else
-    idle=0; seen=1
-    echo "[doctor] $(date -Is) sweep=$sweep matching_tasks=$n -- sweeping"
+    idle=0; seen=1; barrier=0
+    echo "[doctor] $(date -Is) sweep=$sweep matching_tasks=$n (${n_run} running, ${n_pend} pending) -- sweeping"
     ROOT="$ROOT" PATTERN="$PATTERN" bash "$ROOT/degen_watch.sh" $ACT 2>&1 \
       | grep -vE '^  ok ' | sed 's/^/[doctor]   /'
   fi

--- a/man/doctor_watch_steps.Rd
+++ b/man/doctor_watch_steps.Rd
@@ -69,6 +69,16 @@ the final step:
 directory is then empty, stops the doctor.
 }
 
+Pass the same directory to the doctor itself as \code{WATCH_DIR} when you
+submit it. The teardown step is the primary stop signal and is immediate, but
+the doctor also self-terminates after a run of empty sweeps, and \code{WATCH_DIR}
+is what tells it which kind of empty queue it is looking at. With a campaign
+still registered it waits the full \code{IDLE_EXIT}, treating an empty queue as
+a lull between steps; with nothing registered it exits after the shorter
+\code{IDLE_FAST}. The watch list only ever makes it more patient, and
+\code{IDLE_EXIT} still caps the wait, so a stale marker left by a workflow that
+died before its teardown ran cannot hold the doctor open to its walltime.
+
 Because each campaign removes its own marker before testing emptiness,
 whichever campaign finishes last always observes an empty directory. No
 concurrent sibling is ever left unmonitored, and there is no interleaving in


### PR DESCRIPTION
Closes #55, closes #54.

Both issues turn on the same missing distinction. The sweep loop counted RUNNING and PENDING together, so it could not tell "nothing is running" from "nothing is left", and neither could its log. Splitting the count resolves both.

## Pending-side barriers (#55)

slurmworkflow only submits the next slice when the last task of the current one finishes, so a single queued straggler stops all netsim progress. There is no process to probe, so the CPU/D-state detector is blind to it. The old loop logged an ordinary `sweeping` line and the worker replied `no running tasks`. In the India rollout that ran for nine hours across 55 consecutive sweeps.

Sweeps with tasks pending and none running are now counted, the pointless sweep is skipped, and past `BARRIER_WARN` (3) each one reports the duration and every pending task's SLURM reason:

```
sweep=57 !! BARRIER matching_tasks=1 (0 running, 1 pending) for 90m -- no netsim progress
    pending 41746874_33     reason=Resources
```

The reason field separates a scheduler-starved task from one the doctor itself requeued to the back of a deep queue, which is a documented way a rescue becomes the barrier.

Observability only. It does not touch slice progression, so it carries none of the double-write risk that keeps the doctor out of pipelining.

Counting now uses `squeue -r`, so a collapsed pending range like `41746874_[46-63]` contributes the 18 tasks it holds rather than 1. On the live campaign that is 43 rather than 26, so `matching_tasks` will read higher for the same queue.

## Clean exit (#54)

The doctor took an hour of empty sweeps to notice a finished campaign. A naive fast exit is unsafe: it cannot tell an inter-step lull from an ending, and the doctor is shared across every campaign matching `PATTERN`.

Note that #54 predates `add_doctor_teardown_step()`, so its option 1 already exists and is already in use. That left two independent shutdown paths that did not know about each other. The doctor now reads the same watch list the teardown maintains, passed as `WATCH_DIR`:

- campaign registered: an empty queue is a lull, wait the full `IDLE_EXIT` (unchanged, 6 sweeps)
- none registered: exit after `IDLE_FAST` (2 sweeps, 20 minutes instead of 60)

The watch list can only make the doctor more patient, never less, and `IDLE_EXIT` still caps the wait either way. That cap is the point: a workflow killed before its teardown step leaves its marker behind forever, and without it the stale marker would hold the doctor open for its full three-day walltime, which is worse than the problem being fixed. Teardown stays the primary stop signal and is unaffected.

`IDLE_FAST = 2` is measured rather than guessed. Across 103 sweeps and 20.5 hours of a live campaign the matching-task count never once reached zero, so empty-queue states during a running campaign are rare.

## Compatibility

All new knobs (`IDLE_FAST`, `BARRIER_WARN`, `WATCH_DIR`) default to safe values, and `WATCH_DIR` unset gives the queue-only behaviour. `matching_tasks=N` and `-- sweeping` survive unchanged in the log lines, so existing greps still match. A relative `WATCH_DIR` resolves against the submission directory, since the script cd's into `ROOT`.

## Verification

Stubbed `squeue` states, seven cases: counts split correctly; a barrier warns at `BARRIER_WARN` and resets on recovery rather than latching; all three exit paths take the right threshold; a relative `WATCH_DIR` resolves against the submit dir; and the `seen` gate still refuses to exit before any work has appeared, which is what protects a doctor launched ahead of a 180-minute renv restore.

#53 is deliberately not in scope. It is blocked on cross-cluster data by its own terms and it changes requeue behaviour, unlike anything here.
