### PR TITLE
Add a NEWS.md, salvaged from the closed v2.7 branch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,51 @@
+# EpiModelHPC 2.8.0
+
+## BREAKING CHANGES
+
+- Removed the pre-`slurmworkflow` HPC path. It was driven by environment variables exported from a hand-written master sbatch script, and nothing in the package or in any current project still reached it. Replacements:
+  - `netsim_hpc()`: use `EpiModel::netsim()` directly, with `ncores` in `control.net()` for parallelism.
+  - `check_cp()`, `initialize_cp()`, `save_cpdata()`: use EpiModel's `.checkpoint.dir` and `.checkpoint.steps` in `control.net()`.
+  - `savesim()`, `merge_simfiles()`, `process_simfiles()`: use `merge_netsim_scenarios()` or `merge_netsim_scenarios_tibble()`.
+  - `sbatch_master()`: use the `slurmworkflow` step templates, `step_tmpl_netsim_scenarios()` and friends.
+  - `pull_env_vars()`: handled internally by `slurmworkflow`.
+  - `verbose.hpc.net()`: no replacement. It printed progress for `netsim_hpc()` only.
+
+- Dropped dependencies, all unused once the above went: `doParallel`, `foreach`, `ergm`, `tergm`, `tidyr`, and `network` from Suggests.
+
+## OTHER
+
+- `CLAUDE.md` and `_pkgdown.yml` are excluded from the built package.
+- Removed `test-netsimpar.R`, which exercised `EpiModel::netsim()` rather than anything in this package.
+- Refreshed stale metadata: the `Description` field no longer advertises PBS check-pointing, the package documentation no longer carries a hand-maintained version table, and three dead URLs are fixed.
+
+# EpiModelHPC 2.7.0
+
+## NEW FEATURES
+
+- The deploy doctor reports pending-side barriers. `slurmworkflow` submits netsim in slices and the next slice only goes in when the last task of the current one finishes, so one queued straggler stops all progress. There is no process to probe, so the CPU detector was blind to it. Sweeps with tasks pending and none running are now counted and, past `BARRIER_WARN`, reported with each pending task's SLURM reason. Observability only; slice progression is untouched.
+
+- The deploy doctor exits promptly when a campaign really is finished. It reads the same watch list `add_doctor_teardown_step()` maintains, passed as `WATCH_DIR`. With a campaign still registered an empty queue is treated as a lull between steps and it waits the full `IDLE_EXIT`; with none registered it exits after the shorter `IDLE_FAST`. The watch list can only make it more patient, so a stale marker cannot hold it open to its walltime.
+
+## BUG FIXES
+
+- Task counting uses `squeue -r`, so a collapsed pending array range contributes the tasks it actually holds rather than one. Reported counts read higher than before for the same queue.
+
+# EpiModelHPC 2.6.4
+
+## BREAKING CHANGES
+
+- `swf_configs_rsph()` no longer takes `git_version` and no longer loads git. Git is the system binary on the RSPH compute nodes, verified against the cluster. `swf_configs_hyak()` is unchanged.
+
+## OTHER
+
+- `swf_configs_rsph()` defaults `r_version` to 4.5.1, up from 4.2.1.
+
+# EpiModelHPC 2.6.0
+
+## NEW FEATURES
+
+- `swf_cleanup_r_workers()` returns bash lines trapping `TERM` and `EXIT` to reap a job's own R workers. RSPH runs `proctrack/linuxproc` with no cgroup containment, so PSOCK workers reparent to init and survive `scancel`, staying pinned to cores SLURM has already re-allocated. One cancelled calibration array left 163 orphans on 15 nodes for about 2.5 hours. `swf_configs_rsph()` appends the trap to `r_loader` by default; set `cleanup_workers = FALSE` to opt out.
+
+- `hpc_doctor_script()` locates four bundled shell tools that detect and recover degenerate SLURM tasks by measuring CPU utilisation rather than elapsed runtime. See `inst/hpc_doctor/README.md`.
+
+- `add_doctor_register_step()` and `add_doctor_teardown_step()` maintain a watch list so a deploy doctor shared across concurrent campaigns is stopped only when the last one finishes.


### PR DESCRIPTION
Salvaged from #50, which is now closed as superseded.

Adrien wrote a breaking-changes writeup on the `v2.7` branch that never landed. His replacement table for the removed legacy functions is the useful part and it is kept nearly verbatim, brought forward to describe what actually shipped rather than what that branch proposed.

Covers the four releases this work produced:

- **2.8.0** the legacy removal and dependency pruning (#58)
- **2.7.0** pending-side barrier reporting and the faster doctor exit (#57)
- **2.6.4** the RSPH config changes, `git_version` removal and the R 4.5.1 default (#51)
- **2.6.0** `swf_cleanup_r_workers()`, the HPC doctor, and the watch-list steps (#52)

One sequencing note: **merge this after #58**, which is what sets the version to 2.8.0. Landing it first would leave `NEWS.md` describing a version `DESCRIPTION` does not yet claim. There is no file conflict either way.