### PR TITLE
Call swfcalib::load_calib_object() and get_default_proposal() with ::

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EpiModelHPC
-Version: 2.8.1
+Version: 2.8.2
 Date: 2026-07-28
 Title: EpiModel Extensions for High-Performance Computing
 Description: Extension package to EpiModel to run large-scale stochastic network

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# EpiModelHPC 2.8.2
+
+## OTHER
+
+- `make_calibrated_scenario()` calls `swfcalib::load_calib_object()` and `swfcalib::get_default_proposal()` with `::` now that both are exported (EpiModel/swfcalib#34), clearing the `:::` NOTE from `R CMD check`. Requires a swfcalib built from `main` at or after that merge; the version there is unchanged at 0.0.0.9000, so `DESCRIPTION` cannot state the requirement.
+
 # EpiModelHPC 2.8.1
 
 ## BUG FIXES

--- a/R/swfcalib_helpers.R
+++ b/R/swfcalib_helpers.R
@@ -16,16 +16,9 @@ netsim_run_swfcalib_scenario <- function(calib_object, batch_num,
 #' Make an EpiModel scenario using the result of an `swfcalib` calibration
 #'
 #' @inheritParams swfcalib::calibration_step1
-# `load_calib_object()` and `get_default_proposal()` are not exported by swfcalib
-# and have no public equivalent, so they have to be reached inside its namespace.
-# R CMD check NOTEs the `:::`, and that NOTE is left standing deliberately: the
-# alternatives (utils::getFromNamespace, or moving swfcalib to Suggests) only
-# hide the coupling from the checker, and the second would stop
-# `remotes::install_github()` pulling swfcalib in. The real fix is to export both
-# from swfcalib, after which these become plain `swfcalib::` calls.
 make_calibrated_scenario <- function(calib_object) {
-  calib_object <- swfcalib:::load_calib_object(calib_object)
-  calibrated_scenario <- swfcalib:::get_default_proposal(calib_object)
+  calib_object <- swfcalib::load_calib_object(calib_object)
+  calibrated_scenario <- swfcalib::get_default_proposal(calib_object)
   swfcalib_proposal_to_scenario(calibrated_scenario)
 }
 


### PR DESCRIPTION
`swfcalib` now exports both functions (EpiModel/swfcalib#34), so `make_calibrated_scenario()` can call them with `::` instead of reaching into the namespace:

```r
calib_object <- swfcalib::load_calib_object(calib_object)
calibrated_scenario <- swfcalib::get_default_proposal(calib_object)
```

That clears the `:::` NOTE. `R CMD check` on this branch is 0 errors, 0 warnings, 0 notes.

The comment above the function explained why the `:::` was there and said exporting both from swfcalib was the real fix. That has happened, so the comment goes too.

One caveat worth flagging: swfcalib's version is still `0.0.0.9000`, unchanged across that merge, so `DESCRIPTION` cannot express "at or after #34" as a version constraint. `Imports: swfcalib` stays unversioned and the gap is noted in NEWS. Anyone with an older swfcalib build needs to reinstall from main or this package will not load. If we want that enforceable, swfcalib needs a version bump.

Also bumps the version to 2.8.2 and opens that NEWS section, since the entry needs somewhere to live.
