### PR TITLE
Never let the doctor judge the job it is running inside

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EpiModelHPC
-Version: 2.9.0
+Version: 2.9.1
 Date: 2026-07-28
 Title: EpiModel Extensions for High-Performance Computing
 Description: Extension package to EpiModel to run large-scale stochastic network

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# EpiModelHPC 2.9.1
+
+## BUG FIXES
+
+- `degen_watch.sh` no longer judges the job it is running inside. The doctor's own job name necessarily matches `PATTERN`, since that is how it is scoped to a campaign, so it sits inside its own task set; and once the process scan widened past `pgrep -x R` in 2.9.0, its own `sleep` and `ssh` processes became visible too. That reads as a task at 0% CPU with nothing in D-state, which is exactly the `hung` signature, so the doctor confirmed itself hung once per sweep and would have requeued itself. Caught on the first campaign to run 2.9.0: ten consecutive confirmations of the doctor's own job id, spared only because its restart counter already sat at `MAX_RESTARTS`. Any task whose `jobid` equals `SLURM_JOB_ID` is now skipped before classification.
+
 # EpiModelHPC 2.9.0
 
 ## NEW FEATURES

--- a/inst/hpc_doctor/degen_watch.sh
+++ b/inst/hpc_doctor/degen_watch.sh
@@ -141,6 +141,16 @@ while read -r node rest; do
   jid=$(sed -n 's/.*jobid=\([0-9]*\).*/\1/p' <<< "$rest")
   med=$(sed -n 's/.*med_cpu=\([0-9]*\).*/\1/p' <<< "$rest")
   [ -n "${jid:-}" ] && [ -n "${med:-}" ] || continue
+  # Never judge the job this sweep is running inside. The doctor's own job name
+  # necessarily matches PATTERN (that is how it is scoped to a campaign), so it
+  # is inside its own `owned` set, and since the scan widened past `pgrep -x R`
+  # its own `sleep` and ssh processes are visible too. That reads as a task at
+  # 0% CPU with nothing in D-state, which is precisely the `hung` signature, and
+  # the doctor would requeue ITSELF once per sweep. Seen in production the first
+  # time this shipped: ten consecutive confirmations of jobid 41750366, which
+  # was the doctor, spared only by its restart counter already sitting at
+  # MAX_RESTARTS.
+  if [ -n "${SLURM_JOB_ID:-}" ] && [ "$jid" = "$SLURM_JOB_ID" ]; then continue; fi
   # Falls back to jid only for a probe old enough to predate `taskid=`; a
   # same-vintage probe always supplies it.
   tid=$(sed -n 's/.*taskid=\([0-9_]*\).*/\1/p' <<< "$rest"); tid=${tid:-$jid}


### PR DESCRIPTION
The doctor's own job name necessarily matches `PATTERN`, because that is how it is scoped to a campaign, so it has always been inside its own task set. Before 2.9.0 that was harmless: `pgrep -x R` found no R processes for a bash-and-ssh job, so it never appeared in a probe. Widening the scan to every process carrying a `SLURM_JOB_ID` (#63) made its own `sleep` and `ssh` children visible, and a job whose processes sit at 0% CPU with nothing in D-state is precisely the `hung` signature #62 taught it to recognise.

Caught on the first campaign to run 2.9.0, within three hours of launch:

```
[doctor]     41750366: HUNG 0% with 6 proc(s) and none in D-state (idle, not contended)
[doctor]     41750366: CONFIRMED HUNG 0% on node64 (age 71m, restarts 3)
[doctor]        restarts exhausted; leaving it
```

Ten consecutive confirmations, every one of them jobid `41750366`, which was the doctor itself. It never acted only because `Restarts=3` already sat at `MAX_RESTARTS`. Without that it would have requeued itself once per sweep, which on a `--requeue` doctor means killing and restarting the only thing watching the campaign, indefinitely.

## Change

Any probed task whose `jobid` equals `SLURM_JOB_ID` is skipped before classification.

## Verification

Against the live 64-task campaign, both ways:

- Run by hand with no `SLURM_JOB_ID`, the doctor's job still appears in the sweep, spared only by the unrelated `nproc < MIN_PROC` rule.
- Run with `SLURM_JOB_ID` set to that job, it does not appear at all.
- The 64 real tasks are judged identically in both, and the sweep still ends `all tasks healthy`.

Version 2.9.1, with a NEWS entry. Already hot-patched into the running campaign's library so the live doctor is not exposed while this is in review.